### PR TITLE
Support: Cygwin g++

### DIFF
--- a/manager/Makefile
+++ b/manager/Makefile
@@ -1,4 +1,9 @@
 CXXFLAGS= -g -Wall -std=c++14
+ifeq ($(shell uname -o),Cygwin)
+ifneq ($(shell ${CXX} --version | grep -i gcc),)
+CXXFLAGS= -g -Wall
+endif
+endif
 CXX= c++
 LDFLAGS= -lm -lpthread
 OBJECTS= main.o field.o gamelog.o playgame.o


### PR DESCRIPTION
g++ with -std=c++14 option on Cygwin can not use some functions like kill(2) and usleep(3).

For details, see below page:
* [20201127: Cygwin - g++ で kill() が呼べない](https://seesaawiki.jp/w/kou1okada/d/20201127%3a%20Cygwin%20%2d%20g%2b%2b%20%a4%c7%20kill%28%29%20%a4%ac%b8%c6%a4%d9%a4%ca%a4%a4)